### PR TITLE
Make board full screen and match image

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -24,3 +24,93 @@ body {
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }
+
+/* === Classic Minesweeper Theme === */
+:root {
+  --ms-bg: #bdbdbd;
+  --ms-hi: #ffffff;
+  --ms-mid: #bdbdbd;
+  --ms-lo: #7b7b7b;
+  --ms-dk: #4d4d4d;
+  --ms-led-bg: #300000;
+  --ms-led-fg: #ff2a2a;
+}
+
+.ms-panel {
+  display: grid;
+  grid-template-columns: 1fr auto 1fr;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 10px;
+  background: var(--ms-bg);
+  box-shadow: inset -2px -2px 0 var(--ms-lo), inset 2px 2px 0 var(--ms-hi);
+  border: 2px solid var(--ms-dk);
+}
+
+.ms-led {
+  justify-self: start;
+  font-family: "Courier New", Courier, monospace;
+  color: var(--ms-led-fg);
+  background: var(--ms-led-bg);
+  border: 2px solid var(--ms-dk);
+  padding: 4px 8px;
+  font-weight: 700;
+  width: 64px;
+  text-align: center;
+  letter-spacing: 2px;
+  border-radius: 3px;
+  box-shadow: inset 0 0 6px rgba(0,0,0,0.6);
+}
+
+.ms-smiley {
+  justify-self: center;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  background: #ffd83d;
+  border: 2px solid var(--ms-dk);
+  box-shadow: inset -2px -2px 0 rgba(0,0,0,0.15), inset 2px 2px 0 rgba(255,255,255,0.6);
+}
+.ms-smiley:active { transform: translateY(1px); }
+
+.ms-board {
+  display: grid;
+  background: var(--ms-bg);
+  padding: 8px;
+  gap: 0;
+  box-shadow: inset -2px -2px 0 var(--ms-lo), inset 2px 2px 0 var(--ms-hi);
+  border: 2px solid var(--ms-dk);
+}
+
+.ms-cell,
+.ms-cell-revealed {
+  width: var(--ms-cell-size);
+  height: var(--ms-cell-size);
+  line-height: 1;
+  user-select: none;
+}
+
+/* Raised unrevealed cell */
+.ms-cell {
+  background: var(--ms-mid);
+  box-shadow: inset -2px -2px 0 var(--ms-lo), inset 2px 2px 0 var(--ms-hi);
+  border: 1px solid var(--ms-dk);
+}
+.ms-cell:hover { filter: brightness(1.03); }
+
+/* Sunken revealed cell */
+.ms-cell-revealed {
+  background: #d6d6d6;
+  box-shadow: inset 2px 2px 0 var(--ms-lo), inset -2px -2px 0 var(--ms-hi);
+  border: 1px solid var(--ms-dk);
+}
+
+/* Number colors */
+.ms-n1 { color: #0000ff; }
+.ms-n2 { color: #008000; }
+.ms-n3 { color: #ff0000; }
+.ms-n4 { color: #000080; }
+.ms-n5 { color: #800000; }
+.ms-n6 { color: #008080; }
+.ms-n7 { color: #000000; }
+.ms-n8 { color: #606060; }


### PR DESCRIPTION
Remove difficulty selection and make the Minesweeper board full-screen with classic UI styling.

---
<a href="https://cursor.com/background-agent?bcId=bc-4c07925e-03ce-43c4-b36c-029089588270">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-4c07925e-03ce-43c4-b36c-029089588270">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

