### PR TITLE
Enable right clicks for mobile

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -88,6 +88,9 @@ body {
   height: var(--ms-cell-size);
   line-height: 1;
   user-select: none;
+  -webkit-tap-highlight-color: transparent;
+  -webkit-touch-callout: none;
+  touch-action: manipulation;
 }
 
 /* Raised unrevealed cell */


### PR DESCRIPTION
Enable mobile gameplay for Minesweeper by adding touch controls: long-press to flag and tap to reveal cells.

---
<a href="https://cursor.com/background-agent?bcId=bc-7150223f-0ddc-4245-abbc-f6aed867deef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-7150223f-0ddc-4245-abbc-f6aed867deef">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

