### PR TITLE
Fix the header

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -38,7 +38,7 @@ body {
 
 .ms-panel {
   display: grid;
-  grid-template-columns: 1fr auto 1fr;
+  grid-template-columns: auto 1fr auto;
   align-items: center;
   gap: 12px;
   padding: 8px 10px;
@@ -61,6 +61,10 @@ body {
   border-radius: 3px;
   box-shadow: inset 0 0 6px rgba(0,0,0,0.6);
 }
+
+/* Keep counters flush to edges on wide and narrow screens */
+.ms-panel > .ms-led:first-child { justify-self: start; }
+.ms-panel > .ms-led:last-child { justify-self: end; }
 
 .ms-smiley {
   justify-self: center;

--- a/app/minesweeper/page.tsx
+++ b/app/minesweeper/page.tsx
@@ -123,7 +123,7 @@ function countFlagsAround(board: Cell[][], r: number, c: number) {
 export default function MinesweeperPage() {
   // Sizing constants resembling classic Minesweeper
   const CELL_SIZE = 28; // px
-  const HEADER_HEIGHT = 56; // px
+  const HEADER_HEIGHT = 64; // px
   const PADDING = 12; // px around the board
 
   const computeConfig = useCallback((): BoardConfig => {
@@ -417,7 +417,7 @@ export default function MinesweeperPage() {
       style={{ ["--ms-cell-size" as any]: `${CELL_SIZE}px` }}
     >
       <div className="w-full max-w-full px-2 pt-2">
-        <div className="ms-panel" style={{ height: HEADER_HEIGHT - 16 }}>
+        <div className="ms-panel">
           <div className="ms-led">{pad3(minesRemaining)}</div>
           <button className="ms-smiley" onClick={() => reset()} aria-label="reset">
             {gameOver ? (isWin ? "😎" : "😵") : "😊"}


### PR DESCRIPTION
Adjust header layout to correctly align counters and smiley, and prevent clipping on mobile.

The previous header grid layout (`1fr auto 1fr`) did not correctly push the counters to the edges, leading to a cramped appearance. Additionally, a fixed inline height and insufficient `HEADER_HEIGHT` constant caused content clipping on smaller screens. This PR updates the grid to `auto 1fr auto` with explicit alignment rules for the counters, removes the fixed inline height, and increases `HEADER_HEIGHT` to ensure proper spacing and prevent clipping.

---
<a href="https://cursor.com/background-agent?bcId=bc-f9474393-351a-42b6-a76d-708c3436362a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f9474393-351a-42b6-a76d-708c3436362a">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

