### PR TITLE
Implement auto-reveal adjacent squares

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -327,11 +327,19 @@ export default function MinesweeperPage() {
   const onCellMouseDown = useCallback((e: MouseEvent, r: number, c: number) => {
     e.preventDefault();
     if (e.button === 0) {
-      if (tool === "flag") toggleFlag(r, c);
-      else revealCell(r, c);
+      if (tool === "flag") {
+        toggleFlag(r, c);
+      } else {
+        const cell = board[r][c];
+        if (cell.isRevealed && cell.neighborMines > 0) {
+          chordReveal(r, c);
+        } else {
+          revealCell(r, c);
+        }
+      }
     }
     else if (e.button === 2) toggleFlag(r, c);
-  }, [revealCell, toggleFlag, tool]);
+  }, [board, chordReveal, revealCell, toggleFlag, tool]);
 
   const onCellDoubleClick = useCallback((e: MouseEvent, r: number, c: number) => {
     e.preventDefault();
@@ -381,10 +389,18 @@ export default function MinesweeperPage() {
     clearLongPressTimer();
     touchStartPosRef.current = null;
     if (!wasLong) {
-      if (tool === "flag") toggleFlag(r, c);
-      else revealCell(r, c);
+      if (tool === "flag") {
+        toggleFlag(r, c);
+      } else {
+        const cell = board[r][c];
+        if (cell.isRevealed && cell.neighborMines > 0) {
+          chordReveal(r, c);
+        } else {
+          revealCell(r, c);
+        }
+      }
     }
-  }, [revealCell, toggleFlag, clearLongPressTimer, tool]);
+  }, [board, chordReveal, revealCell, toggleFlag, clearLongPressTimer, tool]);
 
   const onCellTouchCancel = useCallback(() => {
     clearLongPressTimer();


### PR DESCRIPTION
Implement auto-reveal on revealed numbered cells when adjacent flags match the cell's number.

---
<a href="https://cursor.com/background-agent?bcId=bc-86532335-25f9-496d-831b-cd959551bafc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-86532335-25f9-496d-831b-cd959551bafc">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

