### PR TITLE
Notify about pwa mobile installation

### DIFF
--- a/app/components/InstallPrompt.tsx
+++ b/app/components/InstallPrompt.tsx
@@ -1,0 +1,128 @@
+"use client";
+
+import { useEffect, useMemo, useRef, useState } from "react";
+
+type DeferredPromptEvent = Event & {
+  prompt: () => Promise<void>;
+  userChoice?: Promise<{ outcome: "accepted" | "dismissed" }>;
+};
+
+function isIos(userAgent: string): boolean {
+  const ua = userAgent || "";
+  // iPhone, iPad, iPod on iOS 13+ identifies as Mac with touch
+  const iOSLike = /iPhone|iPad|iPod/i.test(ua) || (/(Macintosh|Mac OS X)/.test(ua) && typeof navigator !== "undefined" && (navigator as any).maxTouchPoints > 1);
+  return iOSLike;
+}
+
+function isStandaloneMode(): boolean {
+  if (typeof window === "undefined") return false;
+  // iOS Safari
+  const iosStandalone = (window.navigator as any).standalone;
+  // All browsers supporting display-mode media query
+  const displayModeStandalone = window.matchMedia && window.matchMedia("(display-mode: standalone)").matches;
+  return Boolean(iosStandalone || displayModeStandalone);
+}
+
+const DISMISS_KEY = "pwa_install_banner_dismissed_v1";
+
+export default function InstallPrompt() {
+  const [isVisible, setIsVisible] = useState(false);
+  const [showIosTip, setShowIosTip] = useState(false);
+  const deferredPromptRef = useRef<DeferredPromptEvent | null>(null);
+
+  const isMobile = useMemo(() => {
+    if (typeof navigator === "undefined") return false;
+    return /Mobi|Android|iPhone|iPad|iPod/i.test(navigator.userAgent);
+  }, []);
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    if (!isMobile) return;
+    if (isStandaloneMode()) return; // Already installed/opened standalone
+    if (localStorage.getItem(DISMISS_KEY) === "1") return; // User dismissed
+
+    const onBeforeInstallPrompt = (e: Event) => {
+      e.preventDefault?.();
+      deferredPromptRef.current = e as DeferredPromptEvent;
+      setShowIosTip(false);
+      setIsVisible(true);
+    };
+
+    const onAppInstalled = () => {
+      setIsVisible(false);
+    };
+
+    window.addEventListener("beforeinstallprompt", onBeforeInstallPrompt as any);
+    window.addEventListener("appinstalled", onAppInstalled);
+
+    // iOS Safari does not fire beforeinstallprompt
+    if (isIos(navigator.userAgent)) {
+      setShowIosTip(true);
+      setIsVisible(true);
+    }
+
+    return () => {
+      window.removeEventListener("beforeinstallprompt", onBeforeInstallPrompt as any);
+      window.removeEventListener("appinstalled", onAppInstalled);
+    };
+  }, [isMobile]);
+
+  const handleInstallClick = async () => {
+    const dp = deferredPromptRef.current;
+    if (!dp) return;
+    try {
+      await dp.prompt();
+      const choice = await dp.userChoice?.catch(() => undefined);
+      if (choice && choice.outcome === "dismissed") {
+        // keep banner visible; user can try again or dismiss
+      } else {
+        setIsVisible(false);
+      }
+      deferredPromptRef.current = null;
+    } catch {
+      // ignore
+    }
+  };
+
+  const handleDismiss = () => {
+    localStorage.setItem(DISMISS_KEY, "1");
+    setIsVisible(false);
+  };
+
+  if (!isVisible) return null;
+
+  return (
+    <div className="pwa-banner">
+      <div className="pwa-banner__content">
+        <div className="pwa-banner__text">
+          <strong>Install Minesweeper</strong>
+          {showIosTip ? (
+            <span> Add this app to your Home Screen for a better experience.</span>
+          ) : (
+            <span> Get quick access and offline support by installing.</span>
+          )}
+        </div>
+        <div className="pwa-banner__actions">
+          {showIosTip ? (
+            <a
+              className="pwa-banner__link"
+              href="https://support.apple.com/guide/iphone/add-websites-to-home-screen-iph42ab2f3a7/ios"
+              target="_blank"
+              rel="noreferrer noopener"
+            >
+              How to install
+            </a>
+          ) : (
+            <button className="pwa-banner__button" onClick={handleInstallClick}>
+              Install
+            </button>
+          )}
+          <button className="pwa-banner__dismiss" onClick={handleDismiss} aria-label="Dismiss install banner">
+            ✕
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}
+

--- a/app/globals.css
+++ b/app/globals.css
@@ -25,6 +25,60 @@ body {
   font-family: Arial, Helvetica, sans-serif;
 }
 
+/* === PWA Install Banner === */
+.pwa-banner {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  z-index: 60;
+  padding: 8px;
+}
+.pwa-banner__content {
+  margin: 0 auto;
+  max-width: 720px;
+  background: var(--ms-bg, #f3f3f3);
+  color: var(--foreground);
+  border: 2px solid var(--ms-dk, #333);
+  box-shadow: inset -2px -2px 0 var(--ms-lo, #7b7b7b), inset 2px 2px 0 var(--ms-hi, #ffffff);
+  border-radius: 6px;
+  padding: 10px 12px;
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+}
+.pwa-banner__text {
+  line-height: 1.3;
+}
+.pwa-banner__actions {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.pwa-banner__button,
+.pwa-banner__link {
+  appearance: none;
+  border: 2px solid var(--ms-dk, #333);
+  background: var(--ms-mid, #e0e0e0);
+  padding: 6px 10px;
+  border-radius: 6px;
+  text-decoration: none;
+  color: inherit;
+}
+.pwa-banner__button:active {
+  transform: translateY(1px);
+}
+.pwa-banner__dismiss {
+  appearance: none;
+  background: transparent;
+  border: none;
+  color: inherit;
+  font-size: 18px;
+  line-height: 1;
+  padding: 4px 6px;
+}
+
 /* === Classic Minesweeper Theme === */
 :root {
   --ms-bg: #bdbdbd;

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Geist, Geist_Mono } from "next/font/google";
 import "./globals.css";
 import ServiceWorkerRegistrar from "./sw-register";
+import InstallPrompt from "./components/InstallPrompt";
 
 const geistSans = Geist({
   variable: "--font-geist-sans",
@@ -43,6 +44,7 @@ export default function RootLayout({
         className={`${geistSans.variable} ${geistMono.variable} antialiased`}
       >
         <ServiceWorkerRegistrar />
+        <InstallPrompt />
         {children}
       </body>
     </html>


### PR DESCRIPTION
Add a PWA install notification banner to prompt mobile users for installation.

---
<a href="https://cursor.com/background-agent?bcId=bc-d205e309-e885-4cf4-ba70-d73995c231d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d205e309-e885-4cf4-ba70-d73995c231d1">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

