### PR TITLE
Update manifest images and web app title

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -19,16 +19,19 @@ export const metadata: Metadata = {
   description: "Offline-first Minesweeper built with Next.js",
   manifest: "/manifest.webmanifest",
   themeColor: "#bdbdbd",
+  appleWebApp: {
+    title: "minesweeper",
+  },
   icons: {
     icon: [
-      { url: "/icon-192.png", sizes: "192x192", type: "image/png" },
-      { url: "/icon-512.png", sizes: "512x512", type: "image/png" },
+      { url: "/web-app-manifest-192x192.png", sizes: "192x192", type: "image/png" },
+      { url: "/web-app-manifest-512x512.png", sizes: "512x512", type: "image/png" },
     ],
     apple: [
-      { url: "/icon-192.png", sizes: "192x192", type: "image/png" },
+      { url: "/apple-icon.png", sizes: "180x180", type: "image/png" },
     ],
     other: [
-      { rel: "mask-icon", url: "/maskable-192.png" },
+      // No maskable icons provided in repo; skipping
     ],
   },
 };

--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -7,10 +7,8 @@
   "background_color": "#bdbdbd",
   "theme_color": "#bdbdbd",
   "icons": [
-    { "src": "/icon-192.png", "sizes": "192x192", "type": "image/png" },
-    { "src": "/icon-512.png", "sizes": "512x512", "type": "image/png" },
-    { "src": "/maskable-192.png", "sizes": "192x192", "type": "image/png", "purpose": "maskable" },
-    { "src": "/maskable-512.png", "sizes": "512x512", "type": "image/png", "purpose": "maskable" }
+    { "src": "/web-app-manifest-192x192.png", "sizes": "192x192", "type": "image/png" },
+    { "src": "/web-app-manifest-512x512.png", "sizes": "512x512", "type": "image/png" }
   ]
 }
 


### PR DESCRIPTION
Update manifest and Next.js metadata icon paths and add `apple-mobile-web-app-title`.

---
<a href="https://cursor.com/background-agent?bcId=bc-9167a815-e002-491c-943e-84d1d4061806">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-9167a815-e002-491c-943e-84d1d4061806">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

