### PR TITLE
Debug app manifest for 404 error

### DIFF
--- a/public/manifest.webmanifest
+++ b/public/manifest.webmanifest
@@ -1,7 +1,7 @@
 {
   "name": "Minesweeper",
   "short_name": "Mines",
-  "start_url": "/minesweeper",
+  "start_url": "/",
   "scope": "/",
   "display": "standalone",
   "background_color": "#bdbdbd",

--- a/public/sw.js
+++ b/public/sw.js
@@ -1,11 +1,11 @@
 /* Offline-first service worker for Minesweeper (Next.js app dir) */
-const CACHE_VERSION = 'ms-v1';
+const CACHE_VERSION = 'ms-v2';
 const APP_SHELL_CACHE = `app-shell-${CACHE_VERSION}`;
 const RUNTIME_CACHE = `runtime-${CACHE_VERSION}`;
 
 // Precache core routes and assets necessary to load the app offline
 const PRECACHE_URLS = [
-  '/minesweeper',
+  '/',
   '/manifest.webmanifest',
   '/offline.html'
 ];


### PR DESCRIPTION
Align manifest `start_url` and service worker precache with the root path to resolve 404 on app launch.

---
<a href="https://cursor.com/background-agent?bcId=bc-a8780024-f825-47c2-b6a7-9fc8a3ff4856">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a8780024-f825-47c2-b6a7-9fc8a3ff4856">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

