### PR TITLE
Align grid with header spacing

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -110,6 +110,7 @@ body {
   background: var(--ms-bg);
   box-shadow: inset -2px -2px 0 var(--ms-lo), inset 2px 2px 0 var(--ms-hi);
   border: 2px solid var(--ms-dk);
+  box-sizing: border-box;
 }
 
 .ms-led {
@@ -145,10 +146,11 @@ body {
 .ms-board {
   display: grid;
   background: var(--ms-bg);
-  padding: 8px;
+  padding: 10px;
   gap: 0;
   box-shadow: inset -2px -2px 0 var(--ms-lo), inset 2px 2px 0 var(--ms-hi);
   border: 2px solid var(--ms-dk);
+  box-sizing: border-box;
 }
 
 /* Toolbar for selecting tools (Reveal / Flag) */
@@ -160,6 +162,7 @@ body {
   background: var(--ms-bg);
   box-shadow: inset -2px -2px 0 var(--ms-lo), inset 2px 2px 0 var(--ms-hi);
   border: 2px solid var(--ms-dk);
+  box-sizing: border-box;
 }
 
 .ms-tool {

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -129,10 +129,11 @@ export default function MinesweeperPage() {
 
   const computeConfig = useCallback((): BoardConfig => {
     if (typeof window === "undefined") return { rows: 9, cols: 9, mines: 10 };
+    const frameExtra = 24; // padding (10*2) + border (2*2)
     const availableWidth = Math.max(1, window.innerWidth - PADDING * 2);
     const availableHeight = Math.max(1, window.innerHeight - HEADER_HEIGHT - TOOLBAR_HEIGHT - PADDING * 2);
-    const cols = Math.max(5, Math.floor(availableWidth / CELL_SIZE));
-    const rows = Math.max(5, Math.floor(availableHeight / CELL_SIZE));
+    const cols = Math.max(5, Math.floor((availableWidth - frameExtra) / CELL_SIZE));
+    const rows = Math.max(5, Math.floor((availableHeight - frameExtra) / CELL_SIZE));
     const total = rows * cols;
     const mines = Math.max(1, Math.floor(total * 0.15)); // ~15% density
     return { rows, cols, mines };
@@ -416,6 +417,10 @@ export default function MinesweeperPage() {
 
   const gridTemplate = useMemo(() => ({ gridTemplateColumns: `repeat(${config.cols}, var(--ms-cell-size))` }), [config.cols]);
 
+  // Keep header, toolbar, and board the same outer width so edges align
+  // 2 * padding (10) + 2 * border (2) = 24 extra width
+  const frameWidth = useMemo(() => config.cols * CELL_SIZE + 24, [config.cols]);
+
   const numberClass = (n: number) => {
     if (n <= 0) return "";
     return `ms-n${n}`;
@@ -428,8 +433,8 @@ export default function MinesweeperPage() {
       className="h-screen w-screen overflow-hidden select-none flex flex-col items-center justify-start bg-[#bdbdbd]"
       style={{ ["--ms-cell-size" as any]: `${CELL_SIZE}px` }}
     >
-      <div className="w-full max-w-full px-2 pt-2">
-        <div className="ms-panel">
+      <div className="w-full max-w-full px-2 pt-2 flex justify-center">
+        <div className="ms-panel" style={{ width: frameWidth }}>
           <div className="ms-led">{pad3(minesRemaining)}</div>
           <button className="ms-smiley" onClick={() => reset()} aria-label="reset">
             {gameOver ? (isWin ? "😎" : "😵") : "😊"}
@@ -438,8 +443,8 @@ export default function MinesweeperPage() {
         </div>
       </div>
 
-      <div className="w-full max-w-full px-2 pt-2">
-        <div className="ms-toolbar" style={{ height: TOOLBAR_HEIGHT - 12 }}>
+      <div className="w-full max-w-full px-2 pt-2 flex justify-center">
+        <div className="ms-toolbar" style={{ height: TOOLBAR_HEIGHT - 12, width: frameWidth }}>
           <div className="flex items-center gap-2">
             <button
               className={`ms-tool ${tool === "reveal" ? "ms-tool-active" : ""}`}
@@ -463,7 +468,7 @@ export default function MinesweeperPage() {
       </div>
 
       <div className="w-full h-full px-2 pb-2 flex items-start justify-center">
-        <div className="ms-board" style={gridTemplate} onContextMenu={onContextMenu}>
+        <div className="ms-board" style={{ ...gridTemplate, width: frameWidth }} onContextMenu={onContextMenu}>
           {board.map((row: Cell[], r: number) => (
             row.map((cell: Cell, c: number) => {
               const content = cellContent(cell);


### PR DESCRIPTION
Align the grid, header, and toolbar widths and spacing to fix visual misalignment.

The grid was thinner than the header. This PR applies `box-sizing: border-box`, standardizes padding, and calculates a shared `frameWidth` to ensure consistent outer dimensions and internal spacing across the header, toolbar, and board. Grid dimension calculations were also adjusted to account for padding and borders.

---
<a href="https://cursor.com/background-agent?bcId=bc-68ea7b89-2c6f-42b3-9006-39e5038b419b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-68ea7b89-2c6f-42b3-9006-39e5038b419b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

