### PR TITLE
Reveal adjacent cells in flag mode

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -328,15 +328,13 @@ export default function MinesweeperPage() {
   const onCellMouseDown = useCallback((e: MouseEvent, r: number, c: number) => {
     e.preventDefault();
     if (e.button === 0) {
-      if (tool === "flag") {
+      const cell = board[r][c];
+      if (cell.isRevealed && cell.neighborMines > 0) {
+        chordReveal(r, c);
+      } else if (tool === "flag") {
         toggleFlag(r, c);
       } else {
-        const cell = board[r][c];
-        if (cell.isRevealed && cell.neighborMines > 0) {
-          chordReveal(r, c);
-        } else {
-          revealCell(r, c);
-        }
+        revealCell(r, c);
       }
     }
     else if (e.button === 2) toggleFlag(r, c);
@@ -390,15 +388,13 @@ export default function MinesweeperPage() {
     clearLongPressTimer();
     touchStartPosRef.current = null;
     if (!wasLong) {
-      if (tool === "flag") {
+      const cell = board[r][c];
+      if (cell.isRevealed && cell.neighborMines > 0) {
+        chordReveal(r, c);
+      } else if (tool === "flag") {
         toggleFlag(r, c);
       } else {
-        const cell = board[r][c];
-        if (cell.isRevealed && cell.neighborMines > 0) {
-          chordReveal(r, c);
-        } else {
-          revealCell(r, c);
-        }
+        revealCell(r, c);
       }
     }
   }, [board, chordReveal, revealCell, toggleFlag, clearLongPressTimer, tool]);


### PR DESCRIPTION
Allow clicking a revealed number to chord reveal adjacent cells even when the "flag" tool is selected.

---
<a href="https://cursor.com/background-agent?bcId=bc-e68a3bb4-9c35-4efe-abbf-83816c8d6fdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e68a3bb4-9c35-4efe-abbf-83816c8d6fdd">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

