### PR TITLE
Toggle reveal and flag modes with long press

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -483,14 +483,16 @@ export default function MinesweeperPage() {
       const t = e.touches[0];
       if (!t) return;
       touchStartPosRef.current = { x: t.clientX, y: t.clientY };
-      if (tool !== 'flag') {
-        longPressTimerRef.current = setTimeout(() => {
-          longPressTriggeredRef.current = true;
+      longPressTimerRef.current = setTimeout(() => {
+        longPressTriggeredRef.current = true;
+        if (tool === 'flag') {
+          revealCell(r, c);
+        } else {
           toggleFlag(r, c);
-        }, 400);
-      }
+        }
+      }, 400);
     },
-    [toggleFlag, tool]
+    [revealCell, toggleFlag, tool]
   );
 
   const onCellTouchMove = useCallback(


### PR DESCRIPTION
Implement long-press on cells to perform the opposite action of the current tool mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-b30e768f-eb7d-452a-bef0-cac589d855f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b30e768f-eb7d-452a-bef0-cac589d855f5">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

