### PR TITLE
Lighten grid background color

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -156,7 +156,7 @@ body {
 
 .ms-board {
   display: grid;
-  background: var(--ms-bg);
+  background: #d0d0d0;
   padding: 0;
   gap: 0;
   box-shadow: inset -2px -2px 0 var(--ms-lo), inset 2px 2px 0 var(--ms-hi);


### PR DESCRIPTION
Lighten the grid background color by changing `.ms-board` background to `#d0d0d0`.

---
<a href="https://cursor.com/background-agent?bcId=bc-ba92c418-6fcd-4c69-9059-6c3a302b6d80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-ba92c418-6fcd-4c69-9059-6c3a302b6d80">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

