### PR TITLE
Fix right click flag bug in reveal mode

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -495,7 +495,13 @@ export default function MinesweeperPage() {
         } else {
           revealCell(r, c);
         }
-      } else if (e.button === 2) toggleFlag(r, c);
+      } else if (e.button === 2) {
+        if (tool === 'flag') {
+          revealCell(r, c);
+        } else {
+          toggleFlag(r, c);
+        }
+      }
     },
     [board, chordReveal, revealCell, toggleFlag, tool]
   );


### PR DESCRIPTION
Fix right-click behavior to reveal cells in flag mode and flag cells in reveal mode.

---
<a href="https://cursor.com/background-agent?bcId=bc-b08b4b27-09f5-4581-823b-bf6987a8989d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-b08b4b27-09f5-4581-823b-bf6987a8989d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

