### PR TITLE
Fix and rename disconnect to logout

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -829,10 +829,10 @@ export default function MinesweeperPage() {
                   </p>
                   <button
                     className="ms-button"
-                    onClick={() => signOut({ redirect: false })}
-                    aria-label="Disconnect account"
+                    onClick={() => signOut({ callbackUrl: '/' })}
+                    aria-label="Logout"
                   >
-                    Disconnect
+                    Logout
                   </button>
                 </div>
               ) : (


### PR DESCRIPTION
Fix broken disconnect functionality and rename it to logout.

The previous `signOut({ redirect: false })` was not working as expected. Changing to `signOut({ callbackUrl: '/' })` ensures a reliable logout and redirects the user to the home page.

---
<a href="https://cursor.com/background-agent?bcId=bc-fbbae666-9e4a-47fa-a217-43d6fb50e86d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-fbbae666-9e4a-47fa-a217-43d6fb50e86d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

