### PR TITLE
Update top 10 player ranks in redis

### DIFF
--- a/app/api/rank/route.ts
+++ b/app/api/rank/route.ts
@@ -1,0 +1,30 @@
+import { auth } from '@/auth';
+import { updateLeaderboardTop10 } from '@/lib/redis';
+
+export async function POST(request: Request) {
+  const session = await auth();
+  if (!session || !session.user) {
+    return new Response(JSON.stringify({ error: 'Unauthorized' }), { status: 401 });
+  }
+
+  try {
+    const body = await request.json().catch(() => ({}));
+    const secondsRaw = body?.seconds;
+    const seconds = typeof secondsRaw === 'number' && isFinite(secondsRaw) && secondsRaw >= 0 ? secondsRaw : null;
+    if (seconds === null) {
+      return new Response(JSON.stringify({ error: 'Invalid payload' }), { status: 400 });
+    }
+
+    const userId = (session.user as any).id || session.user.email || session.user.name || 'unknown';
+    const name = session.user.name ?? null;
+    const email = session.user.email ?? null;
+
+    await updateLeaderboardTop10({ userId, name, email, seconds });
+
+    return new Response(JSON.stringify({ ok: true }), { status: 200 });
+  } catch (error) {
+    console.error('rank POST error', error);
+    return new Response(JSON.stringify({ error: 'Server error' }), { status: 500 });
+  }
+}
+

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -316,9 +316,24 @@ export default function MinesweeperPage() {
         }
         setBoard(clone);
         setFlagsPlaced(config.mines);
+        // Background: if authenticated, record result for ranking
+        try {
+          if (status === 'authenticated') {
+            // Avoid duplicate submissions: only send once per win
+            if (!(window as any)._rankSubmitted) {
+              (window as any)._rankSubmitted = true;
+              fetch('/api/rank', {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ seconds }),
+                keepalive: true,
+              }).catch(() => {});
+            }
+          }
+        } catch {}
       }
     },
-    [config.mines]
+    [config.mines, status, seconds]
   );
 
   const revealCell = useCallback(

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -1,0 +1,40 @@
+import { Redis } from '@upstash/redis';
+
+const REDIS_URL = process.env.UPSTASH_REDIS_REST_URL || process.env.REDIS_URL;
+const REDIS_TOKEN = process.env.UPSTASH_REDIS_REST_TOKEN || process.env.REDIS_TOKEN;
+
+function createRedis(): Redis | null {
+  if (REDIS_URL && REDIS_TOKEN) {
+    return new Redis({ url: REDIS_URL, token: REDIS_TOKEN });
+  }
+  if (!REDIS_URL) {
+    console.warn('Redis URL missing. Set REDIS_URL or UPSTASH_REDIS_REST_URL.');
+  }
+  if (!REDIS_TOKEN) {
+    console.warn('Redis token missing. Set REDIS_TOKEN or UPSTASH_REDIS_REST_TOKEN.');
+  }
+  return null;
+}
+
+export const redis: Redis | null = createRedis();
+
+export const LEADERBOARD_KEY = 'leaderboard:top';
+
+export type RankUpdatePayload = {
+  userId: string;
+  name: string | null;
+  email: string | null;
+  // Lower time is better; we store negative seconds to rank ascending times as higher scores
+  seconds: number;
+};
+
+export async function updateLeaderboardTop10(payload: RankUpdatePayload) {
+  if (!redis) return;
+  const member = payload.userId;
+  // We want lower seconds to be ranked higher, so score = -seconds
+  const score = -Math.max(0, Math.floor(payload.seconds));
+  await redis.zadd(LEADERBOARD_KEY, { score, member });
+  // Keep only top 10 (highest scores due to negative seconds => best times)
+  await redis.zremrangebyrank(LEADERBOARD_KEY, 0, -11);
+}
+

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "@auth/core": "^0.40.0",
+    "@upstash/redis": "^1.35.3",
     "next": "15.5.2",
     "next-auth": "5.0.0-beta.29",
     "react": "19.1.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       '@auth/core':
         specifier: ^0.40.0
         version: 0.40.0
+      '@upstash/redis':
+        specifier: ^1.35.3
+        version: 1.35.3
       next:
         specifier: 15.5.2
         version: 15.5.2(react-dom@19.1.0(react@19.1.0))(react@19.1.0)
@@ -364,6 +367,9 @@ packages:
   '@types/react@19.1.12':
     resolution: {integrity: sha512-cMoR+FoAf/Jyq6+Df2/Z41jISvGZZ2eTlnsaJRptmZ76Caldwy1odD4xTr/gNV9VLj0AWgg/nmkevIyUfIIq5w==}
 
+  '@upstash/redis@1.35.3':
+    resolution: {integrity: sha512-hSjv66NOuahW3MisRGlSgoszU2uONAY2l5Qo3Sae8OT3/Tng9K+2/cBRuyPBX8egwEGcNNCF9+r0V6grNnhL+w==}
+
   caniuse-lite@1.0.30001741:
     resolution: {integrity: sha512-QGUGitqsc8ARjLdgAfxETDhRbJ0REsP6O3I96TAth/mVjh2cYzN2u+3AzPP3aVSm2FehEItaJw1xd+IGBXWeSw==}
 
@@ -616,6 +622,9 @@ packages:
     engines: {node: '>=14.17'}
     hasBin: true
 
+  uncrypto@0.1.3:
+    resolution: {integrity: sha512-Ql87qFHB3s/De2ClA9e0gsnS6zXG27SkTiSJwjCc9MebbfapQfuPzumMIUMi38ezPZVNFcHI9sUIepeQfw8J8Q==}
+
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
 
@@ -865,6 +874,10 @@ snapshots:
     dependencies:
       csstype: 3.1.3
 
+  '@upstash/redis@1.35.3':
+    dependencies:
+      uncrypto: 0.1.3
+
   caniuse-lite@1.0.30001741: {}
 
   chownr@3.0.0: {}
@@ -1089,6 +1102,8 @@ snapshots:
   tslib@2.8.1: {}
 
   typescript@5.9.2: {}
+
+  uncrypto@0.1.3: {}
 
   undici-types@6.21.0: {}
 


### PR DESCRIPTION
Add Upstash Redis integration to track and store the top 10 player ranks based on win times for logged-in users.

---
<a href="https://cursor.com/background-agent?bcId=bc-81b9633d-223a-45ac-b4c6-93252cf0f2e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-81b9633d-223a-45ac-b4c6-93252cf0f2e3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

