### PR TITLE
Debug rank modal client error

### DIFF
--- a/app/api/rank/route.ts
+++ b/app/api/rank/route.ts
@@ -15,7 +15,8 @@ export async function POST(request: Request) {
       return new Response(JSON.stringify({ error: 'Invalid payload' }), { status: 400 });
     }
 
-    const userId = (session.user as any).id || session.user.email || session.user.name || 'unknown';
+    const rawId = (session.user as any).id || session.user.email || session.user.name || 'unknown';
+    const userId = typeof rawId === 'string' ? rawId : String(rawId);
     const name = session.user.name ?? null;
     const email = session.user.email ?? null;
 

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -903,12 +903,13 @@ export default function MinesweeperPage() {
               {leaderboardLoading && <div className="ms-copy">Loading…</div>}
               {leaderboardError && <div className="ms-copy" style={{ color: '#b00020' }}>{leaderboardError}</div>}
               {!leaderboardLoading && !leaderboardError && (
-                leaderboardEntries.length > 0 ? (
+                Array.isArray(leaderboardEntries) && leaderboardEntries.length > 0 ? (
                   <ol style={{ listStyle: 'none', padding: 0, margin: 0 }}>
                     {leaderboardEntries.map((e, idx) => {
-                      const display = e.name || e.email || e.userId.slice(0, 6) + '…';
+                      const safeUserId = typeof e.userId === 'string' ? e.userId : String(e.userId ?? '');
+                      const display = e.name || e.email || (safeUserId ? safeUserId.slice(0, 6) + '…' : 'Unknown');
                       return (
-                        <li key={e.userId} style={{ display: 'grid', gridTemplateColumns: '40px 1fr auto', alignItems: 'center', gap: 8, padding: '6px 4px' }}>
+                        <li key={safeUserId || String(idx)} style={{ display: 'grid', gridTemplateColumns: '40px 1fr auto', alignItems: 'center', gap: 8, padding: '6px 4px' }}>
                           <span style={{ fontWeight: 800, textAlign: 'right' }}>{idx + 1}.</span>
                           <span style={{ overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap' }}>{display}</span>
                           <span style={{ fontWeight: 700 }}>{formatSeconds(e.seconds)}</span>

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -30,7 +30,7 @@ export type RankUpdatePayload = {
 
 export async function updateLeaderboardTop10(payload: RankUpdatePayload) {
   if (!redis) return;
-  const member = payload.userId;
+  const member = typeof payload.userId === 'string' ? payload.userId : String(payload.userId);
   // We want lower seconds to be ranked higher, so score = -seconds
   const score = -Math.max(0, Math.floor(payload.seconds));
   // Store basic user metadata for display purposes
@@ -77,7 +77,7 @@ export async function fetchLeaderboardTop10(): Promise<LeaderboardEntry[]> {
     rows.map(async (row: { member: string; score: number }) => {
       const meta = await redis!.hgetall<Record<string, string>>(`user:${row.member}`);
       return {
-        userId: row.member,
+        userId: typeof row.member === 'string' ? row.member : String(row.member),
         seconds: Math.max(0, -Math.floor(Number(row.score || 0))),
         name: meta?.name ? meta.name : null,
         email: meta?.email ? meta.email : null,


### PR DESCRIPTION
Normalize `userId` to string across API and Redis helpers, and harden frontend leaderboard rendering to prevent client-side errors in the rank modal.

---
<a href="https://cursor.com/background-agent?bcId=bc-a5da4f11-947e-4f2e-a323-51fe06da0311">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-a5da4f11-947e-4f2e-a323-51fe06da0311">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

