### PR TITLE
Save and return all difficulty ranks

### DIFF
--- a/app/api/rank/route.ts
+++ b/app/api/rank/route.ts
@@ -1,5 +1,5 @@
 import { auth } from '@/auth';
-import { updateLeaderboardTop10, fetchLeaderboardTop10 } from '@/lib/redis';
+import { updateLeaderboardTop10, fetchLeaderboardTop10All } from '@/lib/redis';
 
 export async function POST(request: Request) {
   const session = await auth();
@@ -11,8 +11,13 @@ export async function POST(request: Request) {
     const body = await request.json().catch(() => ({}));
     const secondsRaw = body?.seconds;
     const seconds = typeof secondsRaw === 'number' && isFinite(secondsRaw) && secondsRaw >= 0 ? secondsRaw : null;
+    const difficultyRaw = body?.difficulty;
+    const difficulty = difficultyRaw === 'easy' || difficultyRaw === 'normal' || difficultyRaw === 'hard' ? difficultyRaw : null;
     if (seconds === null) {
       return new Response(JSON.stringify({ error: 'Invalid payload' }), { status: 400 });
+    }
+    if (!difficulty) {
+      return new Response(JSON.stringify({ error: 'Invalid difficulty' }), { status: 400 });
     }
 
     const firstNonEmpty = (...values: Array<unknown>): string => {
@@ -29,7 +34,7 @@ export async function POST(request: Request) {
     const name = firstNonEmpty(session.user.name) || null;
     const email = firstNonEmpty(session.user.email) || null;
 
-    await updateLeaderboardTop10({ userId, name, email, seconds });
+    await updateLeaderboardTop10({ userId, name, email, seconds, difficulty });
 
     return new Response(JSON.stringify({ ok: true }), { status: 200 });
   } catch (error) {
@@ -40,11 +45,11 @@ export async function POST(request: Request) {
 
 export async function GET() {
   try {
-    const entries = await fetchLeaderboardTop10();
-    return new Response(JSON.stringify({ entries }), { status: 200 });
+    const { easy, normal, hard } = await fetchLeaderboardTop10All();
+    return new Response(JSON.stringify({ easy, normal, hard }), { status: 200 });
   } catch (error) {
     console.error('rank GET error', error);
-    return new Response(JSON.stringify({ entries: [] }), { status: 200 });
+    return new Response(JSON.stringify({ easy: [], normal: [], hard: [] }), { status: 200 });
   }
 }
 

--- a/lib/redis.ts
+++ b/lib/redis.ts
@@ -20,12 +20,19 @@ export const redis: Redis | null = createRedis();
 
 export const LEADERBOARD_KEY = 'leaderboard:top';
 
+export type Difficulty = 'easy' | 'normal' | 'hard';
+
+function leaderboardKeyFor(difficulty: Difficulty): string {
+  return `leaderboard:top:${difficulty}`;
+}
+
 export type RankUpdatePayload = {
   userId: string;
   name: string | null;
   email: string | null;
   // Lower time is better; we store negative seconds to rank ascending times as higher scores
   seconds: number;
+  difficulty: Difficulty;
 };
 
 export async function updateLeaderboardTop10(payload: RankUpdatePayload) {
@@ -51,16 +58,18 @@ export async function updateLeaderboardTop10(payload: RankUpdatePayload) {
   // Only update if this is a better (higher) score than existing
   try {
     // Upstash zscore returns number | null and does not take a generic
-    const previous = await redis.zscore(LEADERBOARD_KEY, member);
+    const key = leaderboardKeyFor(payload.difficulty);
+    const previous = await redis.zscore(key, member);
     if (previous == null || score > previous) {
-      await redis.zadd(LEADERBOARD_KEY, { score, member });
+      await redis.zadd(key, { score, member });
     }
   } catch {
     // fallback: best-effort insert
-    await redis.zadd(LEADERBOARD_KEY, { score, member });
+    const key = leaderboardKeyFor(payload.difficulty);
+    await redis.zadd(key, { score, member });
   }
   // Keep only top 10 (highest scores due to negative seconds => best times)
-  await redis.zremrangebyrank(LEADERBOARD_KEY, 0, -11);
+  await redis.zremrangebyrank(leaderboardKeyFor(payload.difficulty), 0, -11);
 }
 
 export type LeaderboardEntry = {
@@ -70,12 +79,12 @@ export type LeaderboardEntry = {
   email: string | null;
 };
 
-export async function fetchLeaderboardTop10(): Promise<LeaderboardEntry[]> {
+export async function fetchLeaderboardTop10ByDifficulty(difficulty: Difficulty): Promise<LeaderboardEntry[]> {
   if (!redis) return [];
   // Top 10 highest scores (i.e., least seconds)
   // Fetch extra in case we filter out invalid members
   const rows = await redis.zrange<Array<{ member: string; score: number }>>(
-    LEADERBOARD_KEY,
+    leaderboardKeyFor(difficulty),
     0,
     49,
     { rev: true, withScores: true }
@@ -94,7 +103,7 @@ export async function fetchLeaderboardTop10(): Promise<LeaderboardEntry[]> {
 
   if (invalidMembers.length > 0) {
     try {
-      await (redis as any).zrem(LEADERBOARD_KEY, ...invalidMembers);
+      await (redis as any).zrem(leaderboardKeyFor(difficulty), ...invalidMembers);
     } catch {}
   }
 
@@ -118,5 +127,14 @@ export async function fetchLeaderboardTop10(): Promise<LeaderboardEntry[]> {
   );
 
   return results;
+}
+
+export async function fetchLeaderboardTop10All(): Promise<{ easy: LeaderboardEntry[]; normal: LeaderboardEntry[]; hard: LeaderboardEntry[] }> {
+  const [easy, normal, hard] = await Promise.all([
+    fetchLeaderboardTop10ByDifficulty('easy'),
+    fetchLeaderboardTop10ByDifficulty('normal'),
+    fetchLeaderboardTop10ByDifficulty('hard'),
+  ]);
+  return { easy, normal, hard };
 }
 


### PR DESCRIPTION
Add per-difficulty leaderboards and update the API to save by difficulty and return all three ranks at once.

---
<a href="https://cursor.com/background-agent?bcId=bc-d18fd4ad-a9f6-4c05-976b-84c4b00043f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d18fd4ad-a9f6-4c05-976b-84c4b00043f2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

