### PR TITLE
Fix ranking modal data loading loop

### DIFF
--- a/app/Game.tsx
+++ b/app/Game.tsx
@@ -207,13 +207,6 @@ export default function Game(props: {
   const [seconds, setSeconds] = useState<number>(0);
   const [tool, setTool] = useState<'reveal' | 'flag'>('reveal');
   const [isLeaderboardOpen, setIsLeaderboardOpen] = useState<boolean>(false);
-  const [leaderboardLoading, setLeaderboardLoading] = useState<boolean>(false);
-  const [leaderboardError, setLeaderboardError] = useState<string | null>(null);
-  const [leaderboardEntries, setLeaderboardEntries] = useState<{
-    easy: Array<{ userId: string; seconds: number; name: string | null; email: string | null }>;
-    normal: Array<{ userId: string; seconds: number; name: string | null; email: string | null }>;
-    hard: Array<{ userId: string; seconds: number; name: string | null; email: string | null }>;
-  }>({ easy: [], normal: [], hard: [] });
   const timerRef = useRef<ReturnType<typeof setInterval> | null>(null);
   const longPressTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const longPressTriggeredRef = useRef<boolean>(false);
@@ -666,31 +659,7 @@ export default function Game(props: {
     return `${m}m ${s}s`;
   };
 
-  useEffect(() => {
-    if (!isLeaderboardOpen) return;
-    track('open_ranking');
-    let aborted = false;
-    setLeaderboardLoading(true);
-    setLeaderboardError(null);
-    fetchLeaderboard()
-      .then((data) => {
-        if (!aborted) setLeaderboardEntries({
-          easy: Array.isArray(data.easy) ? data.easy : [],
-          normal: Array.isArray(data.normal) ? data.normal : [],
-          hard: Array.isArray(data.hard) ? data.hard : [],
-        });
-      })
-      .catch((e: unknown) => {
-        const message = e instanceof Error ? e.message : 'Failed to load';
-        if (!aborted) setLeaderboardError(message);
-      })
-      .finally(() => {
-        if (!aborted) setLeaderboardLoading(false);
-      });
-    return () => {
-      aborted = true;
-    };
-  }, [isLeaderboardOpen, fetchLeaderboard]);
+  // Ranking modal handles its own fetch on open
 
   return (
     <div


### PR DESCRIPTION
Refactor ranking modal to fetch data only once on open, removing redundant fetching logic from the game component.

---
<a href="https://cursor.com/background-agent?bcId=bc-1d759db5-7548-482f-98f0-95f942a9b8c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1d759db5-7548-482f-98f0-95f942a9b8c0">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

