### PR TITLE
Add spacing to board bottom

### DIFF
--- a/app/Game.tsx
+++ b/app/Game.tsx
@@ -162,7 +162,7 @@ export default function Game(props: {
     );
     const rows = Math.max(
       5,
-      Math.floor((availableHeight - frameExtra) / CELL_SIZE)
+      Math.floor((availableHeight - frameExtra) / CELL_SIZE) - 1
     );
     const total = rows * cols;
     let difficultySaved: Difficulty = 'normal';


### PR DESCRIPTION
Reduce board height by one row to add bottom spacing to the game board.

---
<a href="https://cursor.com/background-agent?bcId=bc-d8513067-2755-4cac-9936-b5794a71a43b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d8513067-2755-4cac-9936-b5794a71a43b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

