### PR TITLE
Fix custom mode win bug

### DIFF
--- a/app/Game.tsx
+++ b/app/Game.tsx
@@ -178,9 +178,9 @@ export default function Game(props: {
       try {
         const raw = window.localStorage.getItem('ms_custom_mines_v1');
         const n = raw == null ? NaN : Number(raw);
-        if (Number.isFinite(n) && n >= 0) custom = Math.floor(n);
+        if (Number.isFinite(n) && n >= 1) custom = Math.floor(n);
       } catch {}
-      const mines = Math.max(0, Math.floor(custom));
+      const mines = Math.max(1, Math.floor(custom));
       return { rows, cols, mines };
     } else {
       const factor = difficultySaved === 'easy' ? 0.1 : difficultySaved === 'hard' ? 0.2 : 0.15;
@@ -214,7 +214,7 @@ export default function Game(props: {
     try {
       const raw = window.localStorage.getItem('ms_custom_mines_v1');
       const n = raw == null ? NaN : Number(raw);
-      if (Number.isFinite(n) && n >= 0) return Math.floor(n);
+      if (Number.isFinite(n) && n >= 1) return Math.floor(n);
     } catch {}
     return 10;
   });
@@ -254,7 +254,7 @@ export default function Game(props: {
   const computeMinesForDifficulty = useCallback(
     (totalCells: number, diff: Difficulty) => {
       if (diff === 'custom') {
-        return Math.max(0, Math.floor(customMines));
+        return Math.max(1, Math.floor(customMines));
       }
       const factor = diff === 'easy' ? 0.1 : diff === 'hard' ? 0.2 : 0.15;
       return Math.max(1, Math.floor(totalCells * factor));
@@ -302,7 +302,7 @@ export default function Game(props: {
   );
 
   const updateCustomMines = useCallback((n: number) => {
-    const sanitized = Number.isFinite(n) && n >= 0 ? Math.floor(n) : 0;
+    const sanitized = Number.isFinite(n) && n >= 1 ? Math.floor(n) : 1;
     setCustomMines(sanitized);
     try {
       if (typeof window !== 'undefined') {

--- a/app/components/Settings.tsx
+++ b/app/components/Settings.tsx
@@ -89,10 +89,10 @@ export default function Settings(props: {
                 <span>Custom</span>
                 <input
                   type="number"
-                  min={0}
+                  min={1}
                   step={1}
-                  value={Number.isFinite(customMines) ? customMines : 0}
-                  onChange={(e: any) => { onChangeCustomMines(Math.max(0, Math.floor(Number(e.target.value)))); if (difficulty === "custom") applyCustom(); }}
+                  value={Number.isFinite(customMines) ? Math.max(1, customMines) : 1}
+                  onChange={(e: any) => { onChangeCustomMines(Math.max(1, Math.floor(Number(e.target.value)))); if (difficulty === "custom") applyCustom(); }}
                   aria-label="Custom bombs count"
                   style={{ width: 96 }}
                 />


### PR DESCRIPTION
Ensure custom game mode always has at least 1 mine to fix instant wins when 0 mines are set.

Previously, custom games configured with 0 mines would instantly register a win on the first click. This change clamps the minimum number of custom mines to 1 across game logic and UI input.

---
<a href="https://cursor.com/background-agent?bcId=bc-c834deaf-01ce-4100-ad62-ef117a4f5e1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c834deaf-01ce-4100-ad62-ef117a4f5e1c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

