### PR TITLE
Center and round smiley button

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -140,10 +140,20 @@ body {
 
 .ms-smiley {
   justify-self: center;
-  border: 0px solid var(--ms-dk);
+  -webkit-appearance: none;
+  appearance: none;
   background: transparent;
+  border: 0px solid var(--ms-dk);
+  /* Force a perfect circle regardless of platform default button paddings */
+  width: 44px;
+  height: 44px;
+  padding: 0;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  line-height: 1;
   border-radius: 50%;
-  font-size: 41px;
+  font-size: 30px;
   box-shadow: inset -2px -2px rgba(0, 0, 0, .15), inset 2px 2px rgba(255, 255, 255, .6);
 }
 .ms-smiley:active {


### PR DESCRIPTION
Make the smiley emoji button perfectly round and centered on mobile.

---
<a href="https://cursor.com/background-agent?bcId=bc-89c09d46-845c-4732-843f-c72449d02de7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-89c09d46-845c-4732-843f-c72449d02de7">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

