### PR TITLE
Adjust custom input background for lighter appearance

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -339,6 +339,22 @@ body {
   max-width: 100%;
 }
 
+/* Make the custom number input look like a proper input */
+.ms-radio input[type="number"] {
+  -webkit-appearance: none;
+  appearance: none;
+  background: #ffffff;
+  color: #111111;
+  border: 2px solid var(--ms-dk);
+  border-radius: 6px;
+  padding: 4px 6px;
+  box-shadow: inset -2px -2px 0 var(--ms-lo), inset 2px 2px 0 var(--ms-hi);
+}
+.ms-radio input[type="number"]:focus-visible {
+  outline: 2px solid var(--ms-led-fg);
+  outline-offset: 2px;
+}
+
 /* Make the Custom mines input shrink on small screens to avoid overflow */
 @media (max-width: 480px) {
   .ms-radio input[type="number"] {


### PR DESCRIPTION
Add styles to the custom number input to give it a lighter background and a beveled border, making it visually consistent with other inputs.

---
<a href="https://cursor.com/background-agent?bcId=bc-49c179e1-07e1-4536-a387-e4829d26e254">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-49c179e1-07e1-4536-a387-e4829d26e254">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

