### PR TITLE
Restore custom input background styling

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -341,7 +341,8 @@ body {
 }
 
 /* Make the custom number input look like a proper input */
-.ms-radio input[type="number"] {
+.ms-radio input[type="number"],
+.ms-radio input[type="text"] {
   -webkit-appearance: none;
   appearance: none;
   background: #ffffff;
@@ -351,14 +352,16 @@ body {
   padding: 4px 6px;
   box-shadow: inset -2px -2px 0 var(--ms-lo), inset 2px 2px 0 var(--ms-hi);
 }
-.ms-radio input[type="number"]:focus-visible {
+.ms-radio input[type="number"]:focus-visible,
+.ms-radio input[type="text"]:focus-visible {
   outline: 2px solid var(--ms-led-fg);
   outline-offset: 2px;
 }
 
 /* Make the Custom mines input shrink on small screens to avoid overflow */
 @media (max-width: 480px) {
-  .ms-radio input[type="number"] {
+  .ms-radio input[type="number"],
+  .ms-radio input[type="text"] {
     width: clamp(64px, 28vw, 96px) !important;
   }
 }


### PR DESCRIPTION
Apply custom input styling to `type="text"` inputs to restore their lighter background and focus state.

---
<a href="https://cursor.com/background-agent?bcId=bc-e32d0ebd-7dd3-4cbe-922c-8c030a2e3d37">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-e32d0ebd-7dd3-4cbe-922c-8c030a2e3d37">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

