### PR TITLE
Remove settings modal tabs

### DIFF
--- a/app/Game.tsx
+++ b/app/Game.tsx
@@ -218,7 +218,6 @@ export default function Game(props: {
 
   const [config, setConfig] = useState<BoardConfig>(() => computeConfig());
   const [isSettingsOpen, setIsSettingsOpen] = useState<boolean>(false);
-  const [activeTab, setActiveTab] = useState<'settings' | 'account'>('settings');
   const [difficulty, setDifficulty] = useState<Difficulty>(() => {
     if (typeof window === 'undefined') return 'normal';
     try {
@@ -859,7 +858,6 @@ export default function Game(props: {
           <button
             className="ms-tool"
             onClick={() => {
-              setActiveTab('settings');
               setIsSettingsOpen(true);
               track('open_settings');
             }}
@@ -889,8 +887,6 @@ export default function Game(props: {
 
       <Settings
         isOpen={isSettingsOpen}
-        activeTab={activeTab}
-        onChangeTab={(t) => setActiveTab(t)}
         onClose={() => setIsSettingsOpen(false)}
         difficulty={difficulty}
         applyDifficulty={applyDifficulty}

--- a/app/components/Settings.tsx
+++ b/app/components/Settings.tsx
@@ -1,14 +1,11 @@
 "use client";
 
-import { signIn, signOut, useSession } from "next-auth/react";
 import { useEffect, useState } from "react";
 
 export type Difficulty = "easy" | "normal" | "hard" | "custom";
 
 export default function Settings(props: {
   isOpen: boolean;
-  activeTab: "settings" | "account";
-  onChangeTab: (tab: "settings" | "account") => void;
   onClose: () => void;
   difficulty: Difficulty;
   applyDifficulty: (d: Difficulty) => void;
@@ -17,8 +14,7 @@ export default function Settings(props: {
   applyCustom: () => void;
   onTrack?: (eventName: string) => void;
 }) {
-  const { isOpen, activeTab, onChangeTab, onClose, difficulty, applyDifficulty, customMines, onChangeCustomMines, applyCustom, onTrack } = props;
-  const { data: session, status } = useSession();
+  const { isOpen, onClose, difficulty, applyDifficulty, customMines, onChangeCustomMines, applyCustom } = props;
 
   // Allow clearing the custom input while typing; commit on blur/Enter
   const [customMinesText, setCustomMinesText] = useState<string>(
@@ -44,130 +40,84 @@ export default function Settings(props: {
   return (
     <div className="ms-modal-overlay" role="dialog" aria-modal="true">
       <div className="ms-modal" role="document">
-        <div className="ms-tabs">
-          <button
-            className={`ms-tab ${activeTab === "settings" ? "ms-tab-active" : ""}`}
-            onClick={() => onChangeTab("settings")}
-            aria-selected={activeTab === "settings"}
-          >
-            Settings
-          </button>
-          <button
-            className={`ms-tab ${activeTab === "account" ? "ms-tab-active" : ""}`}
-            onClick={() => onChangeTab("account")}
-            aria-selected={activeTab === "account"}
-          >
-            Account
-          </button>
-          <button className="ms-tab ms-tab-right" onClick={onClose} aria-label="close" title="Close">
-            ✕
-          </button>
-        </div>
+        <button
+          className="ms-button"
+          onClick={onClose}
+          aria-label="close"
+          title="Close"
+          style={{ position: "absolute", top: 8, right: 8 }}
+        >
+          ✕
+        </button>
 
-        {activeTab === "settings" && (
-          <div className="ms-modal-section">
-            <div className="ms-section-title">Difficulty</div>
-            <div className="ms-radio-group">
-              <label className="ms-radio">
-                <input
-                  type="radio"
-                  name="difficulty"
-                  value="easy"
-                  checked={difficulty === "easy"}
-                  onChange={() => applyDifficulty("easy")}
-                />
-                <span>Easy</span>
-              </label>
-              <label className="ms-radio">
-                <input
-                  type="radio"
-                  name="difficulty"
-                  value="normal"
-                  checked={difficulty === "normal"}
-                  onChange={() => applyDifficulty("normal")}
-                />
-                <span>Normal</span>
-              </label>
-              <label className="ms-radio">
-                <input
-                  type="radio"
-                  name="difficulty"
-                  value="hard"
-                  checked={difficulty === "hard"}
-                  onChange={() => applyDifficulty("hard")}
-                />
-                <span>Hard</span>
-              </label>
-              <label className="ms-radio" style={{ display: "flex", alignItems: "center", gap: 8 }}>
-                <input
-                  type="radio"
-                  name="difficulty"
-                  value="custom"
-                  checked={difficulty === "custom"}
-                  onChange={() => applyCustom()}
-                />
-                <span>Custom</span>
-                <input
-                  type="text"
-                  inputMode="numeric"
-                  pattern="[0-9]*"
-                  min={1}
-                  step={1}
-                  value={customMinesText}
-                  onChange={(e: any) => {
-                    const next = e.target.value;
-                    // Allow empty string and numeric-only input
-                    if (next === "" || /^[0-9]+$/.test(next)) {
-                      setCustomMinesText(next);
-                    }
-                  }}
-                  onBlur={commitCustomMines}
-                  onKeyDown={(e: any) => { if (e.key === "Enter") { e.preventDefault(); commitCustomMines(); } }}
-                  aria-label="Custom bombs count"
-                  style={{ width: 96 }}
-                />
-                <span style={{ opacity: 0.8 }}>
-                  bombs
-                </span>
-              </label>
-            </div>
-            <div className="ms-hint">Custom games do not save to leaderboard.</div>
-            <div className="ms-hint">Changes apply immediately and restart the board.</div>
+        <div className="ms-modal-section">
+          <div className="ms-section-title">Difficulty</div>
+          <div className="ms-radio-group">
+            <label className="ms-radio">
+              <input
+                type="radio"
+                name="difficulty"
+                value="easy"
+                checked={difficulty === "easy"}
+                onChange={() => applyDifficulty("easy")}
+              />
+              <span>Easy</span>
+            </label>
+            <label className="ms-radio">
+              <input
+                type="radio"
+                name="difficulty"
+                value="normal"
+                checked={difficulty === "normal"}
+                onChange={() => applyDifficulty("normal")}
+              />
+              <span>Normal</span>
+            </label>
+            <label className="ms-radio">
+              <input
+                type="radio"
+                name="difficulty"
+                value="hard"
+                checked={difficulty === "hard"}
+                onChange={() => applyDifficulty("hard")}
+              />
+              <span>Hard</span>
+            </label>
+            <label className="ms-radio" style={{ display: "flex", alignItems: "center", gap: 8 }}>
+              <input
+                type="radio"
+                name="difficulty"
+                value="custom"
+                checked={difficulty === "custom"}
+                onChange={() => applyCustom()}
+              />
+              <span>Custom</span>
+              <input
+                type="text"
+                inputMode="numeric"
+                pattern="[0-9]*"
+                min={1}
+                step={1}
+                value={customMinesText}
+                onChange={(e: any) => {
+                  const next = e.target.value;
+                  if (next === "" || /^[0-9]+$/.test(next)) {
+                    setCustomMinesText(next);
+                  }
+                }}
+                onBlur={commitCustomMines}
+                onKeyDown={(e: any) => { if (e.key === "Enter") { e.preventDefault(); commitCustomMines(); } }}
+                aria-label="Custom bombs count"
+                style={{ width: 96 }}
+              />
+              <span style={{ opacity: 0.8 }}>
+                bombs
+              </span>
+            </label>
           </div>
-        )}
-
-        {activeTab === "account" && (
-          status === "authenticated" ? (
-            <div className="ms-modal-section">
-              <div className="ms-section-title">Account</div>
-              <p className="ms-copy">
-                You're signed in as {session?.user?.name || session?.user?.email || 'your account'}.
-              </p>
-              <button
-                className="ms-button"
-                onClick={() => { if (onTrack) onTrack("logout"); signOut({ callbackUrl: "/" }); }}
-                aria-label="Logout"
-              >
-                Logout
-              </button>
-            </div>
-          ) : (
-            <div className="ms-modal-section">
-              <div className="ms-section-title">Get Ranked</div>
-              <p className="ms-copy">
-                Create an account to join the website ranking once it launches. Your best
-                times and wins will appear on the leaderboard.
-              </p>
-              <button
-                className="ms-button"
-                onClick={() => { if (onTrack) onTrack("login_google"); signIn("google"); }}
-                aria-label="Sign in with Google"
-              >
-                Continue with Google
-              </button>
-            </div>
-          )
-        )}
+          <div className="ms-hint">Custom games do not save to leaderboard.</div>
+          <div className="ms-hint">Changes apply immediately and restart the board.</div>
+        </div>
       </div>
       <button className="ms-modal-backdrop" aria-hidden="true" onClick={onClose} />
     </div>


### PR DESCRIPTION
Remove the Accounts tab and the tab header from the settings modal to simplify its interface.

---
<a href="https://cursor.com/background-agent?bcId=bc-04479b13-aacd-451d-a332-aa74e5c85c7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-04479b13-aacd-451d-a332-aa74e5c85c7b">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

