### PR TITLE
Format personal records with total seconds

### DIFF
--- a/app/components/Ranking.tsx
+++ b/app/components/Ranking.tsx
@@ -58,7 +58,7 @@ export default function Ranking(props: {
                   {best ? (
                     <div style={{ display: "grid", gridTemplateColumns: "1fr auto", alignItems: "center", gap: 8, padding: "6px 4px" }}>
                       <span style={{ overflow: "hidden", textOverflow: "ellipsis", whiteSpace: "nowrap" }}>{best.name || 'You'}</span>
-                      <span style={{ fontWeight: 700 }}>{formatSeconds(best.seconds)}</span>
+                      <span style={{ fontWeight: 700 }}>{formatSeconds(best.seconds)} ({best.seconds}s)</span>
                     </div>
                   ) : (
                     <div className="ms-copy">No best score yet.</div>


### PR DESCRIPTION
Add total seconds in parentheses to the personal record display because the game's display only shows seconds.

---
<a href="https://cursor.com/background-agent?bcId=bc-d4217279-460f-4813-8afb-76b3d7560ac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-d4217279-460f-4813-8afb-76b3d7560ac9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

