### PR TITLE
Add clear button to rank modal

### DIFF
--- a/app/components/Ranking.tsx
+++ b/app/components/Ranking.tsx
@@ -39,6 +39,16 @@ export default function Ranking(props: {
     return () => {};
   }, [isOpen]);
 
+  const handleClear = () => {
+    try {
+      if (typeof window !== 'undefined') {
+        window.localStorage.removeItem('ms_best_v1');
+      }
+    } catch {}
+    setMyBest({ easy: null, normal: null, hard: null });
+    if (onTrackRef.current) onTrackRef.current('clear_ranking');
+  };
+
   if (!isOpen) return null;
 
   return (
@@ -66,6 +76,11 @@ export default function Ranking(props: {
                 </div>
               );
             })}
+          </div>
+          <div style={{ marginTop: 12, display: "flex", justifyContent: "flex-end" }}>
+            <button className="ms-button" onClick={handleClear} aria-label="clear-best-scores" title="Clear your best times">
+              Clear
+            </button>
           </div>
         </div>
       </div>


### PR DESCRIPTION
Add a 'Clear' button to the ranking modal to allow users to remove their locally stored best scores.

---
<a href="https://cursor.com/background-agent?bcId=bc-38014eb0-357e-4774-bb7f-e54b2ca0b624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-38014eb0-357e-4774-bb7f-e54b2ca0b624"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

