### PR TITLE
Fix incorrect win declaration on flag toggle

### DIFF
--- a/app/Game.tsx
+++ b/app/Game.tsx
@@ -709,14 +709,12 @@ export default function Game() {
       longPressTimerRef.current = setTimeout(() => {
         longPressTriggeredRef.current = true;
         triggerHapticImpact(15);
-        if (tool === 'flag') {
-          revealCell(r, c);
-        } else {
-          toggleFlag(r, c);
-        }
+        // Long-press should always toggle a flag, independent of the current tool,
+        // to avoid accidental reveals that can incorrectly trigger a win.
+        toggleFlag(r, c);
       }, 400);
     },
-    [revealCell, toggleFlag, tool, triggerHapticImpact]
+    [toggleFlag, triggerHapticImpact]
   );
 
   const onCellTouchMove = useCallback(


### PR DESCRIPTION
Change long-press to always toggle a flag to prevent false wins from accidental cell reveals.

Previously, if the tool was set to 'flag', a long-press would reveal a cell instead of toggling a flag. This could inadvertently start the game and trigger a win condition prematurely, even when the user's intent was solely to manage flags.

---
<a href="https://cursor.com/background-agent?bcId=bc-ab578d32-3fb7-447f-834b-80fe82d195ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ab578d32-3fb7-447f-834b-80fe82d195ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

