### PR TITLE
Fix game flag bug on pc browser

### DIFF
--- a/app/Game.tsx
+++ b/app/Game.tsx
@@ -525,6 +525,10 @@ export default function Game() {
   const revealCell = useCallback(
     (r: number, c: number) => {
       if (gameOver) return;
+      // Do not start the game or place mines if the target cell cannot be revealed
+      const current = board[r][c];
+      if (current.isRevealed || current.isFlagged) return;
+
       let newBoard = cloneBoard(board);
 
       if (isFirstClick) {
@@ -548,7 +552,7 @@ export default function Game() {
       }
 
       const cell = newBoard[r][c];
-      if (cell.isRevealed || cell.isFlagged) return;
+      if (cell.isRevealed) return;
 
       if (cell.isMine) {
         for (let rr = 0; rr < newBoard.length; rr++) {


### PR DESCRIPTION
Fix a bug where the game could fail after flagging, unflagging, and then left-clicking a cell by preventing first-click mine placement on flagged or already revealed cells.

---
<a href="https://cursor.com/background-agent?bcId=bc-c6938d06-71ae-40ed-85d5-3da480331f01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-c6938d06-71ae-40ed-85d5-3da480331f01"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

